### PR TITLE
corrected spectrum description from binary

### DIFF
--- a/R/get-spectrum.r
+++ b/R/get-spectrum.r
@@ -23,25 +23,24 @@
 
   # White reference flag
   # seek(con, 17692) = 484 + 8 * md$channels
-  wr_flag <- readBin(con, what = logical(), size = 1)
+  wr_flag <- readBin(con, what = logical(), size = 2)
 
   # White reference time
-  # seek(con, 17693) = 484 + 8 * md$channels + 1
+  # seek(con, 17694) = 484 + 8 * md$channels + 2
   wr_time <- readBin(con, integer(), size = 8, endian = "little")
 
   # Spectrum time
-  # seek(con, 17701) = 484 + 8 * md$channels + 9
+  # seek(con, 17702) = 484 + 8 * md$channels + 10
   spec_time <- readBin(con, integer(), size = 8, endian = "little")
 
   # Spectrum description length
-  # seek(con, 17709) = 484 + 8 * md$channels + 17
+  # seek(con, 17710) = 484 + 8 * md$channels + 18
   spec_description_length <- readBin(con, integer(), size = 2, endian = "little")
   # Spectrum description
-  # seek(con, 17710) # = 484 + 8 * md$channels + 19
-  spec_description <- readBin(con, character(), size = spec_description_length, endian = "little")
+  # seek(con, 17712) # = 484 + 8 * md$channels + 20
+  spec_description <- readChar(con, nchars = spec_description_length)
 
   # White reference
-  # seek(con, 17712) = 484 + 8 * md$channels + 20
   wr <- readBin(con, what = md$data_format, n = md$channels, endian = "little")
 
   res <- list(spectrum = spec, wr = wr)

--- a/R/get-spectrum.r
+++ b/R/get-spectrum.r
@@ -48,31 +48,14 @@
 
 .process_spectra <- function(spec, md, type) {
   if (type == 'reflectance') {
-    if (md$data_type == 'reflectance') {
-      res <- spec$spectrum
-    } else if (md$data_type == 'raw') {
       res <- .normalise_spectrum(spec$spectrum, md) / .normalise_spectrum(spec$wr, md)
-    } else {
-      stop(paste0('File only contains data of type ', md$data_type, '.'))
-    }
   } else if (type == 'radiance') {
-    if (md$data_type == 'radiance') {
-      res <- spec$spectrum
-    } else if (md$data_type == 'raw') {
       res <- .normalise_spectrum(spec$spectrum, md)
-    } else {
-      stop(paste0('File only contains data of type ', md$data_type, '.'))
-    }
   } else if (type == 'raw') {
-    if (md$data_type == 'raw') {
       res <- spec$spectrum
-    } else {
-      stop(paste0('File only contains data of type ', md$data_type, '.'))
-    }
   } else if (type == 'white_reference') {
     res <- .normalise_spectrum(spec$wr, md)
   } else {
     stop('Invalid type.')
   }
 }
-

--- a/R/get-spectrum.r
+++ b/R/get-spectrum.r
@@ -48,11 +48,27 @@
 
 .process_spectra <- function(spec, md, type) {
   if (type == 'reflectance') {
+    if (md$data_type == 'reflectance') {
+      res <- spec$spectrum / spec$wr
+    } else if (md$data_type == 'raw') {
       res <- .normalise_spectrum(spec$spectrum, md) / .normalise_spectrum(spec$wr, md)
+    } else {
+      stop(paste0('File only contains data of type ', md$data_type, '.'))
+    }
   } else if (type == 'radiance') {
-      res <- .normalise_spectrum(spec$spectrum, md)
-  } else if (type == 'raw') {
+    if (md$data_type == 'radiance') {
       res <- spec$spectrum
+    } else if (md$data_type == 'raw') {
+      res <- .normalise_spectrum(spec$spectrum, md)
+    } else {
+      stop(paste0('File only contains data of type ', md$data_type, '.'))
+    }
+  } else if (type == 'raw') {
+    if (md$data_type == 'raw') {
+      res <- spec$spectrum
+    } else {
+      stop(paste0('File only contains data of type ', md$data_type, '.'))
+    }
   } else if (type == 'white_reference') {
     res <- .normalise_spectrum(spec$wr, md)
   } else {


### PR DESCRIPTION
Correct spectrum description import from binary which prevented white reference data from being imported properly.
Also fixed an issue which prevented reflectance data from being imported. Problem is that ASD binary file contains raw DN for target and white reference regardless of what "data type" is mentioned in the metadata.